### PR TITLE
✨ RE_01 검증 내역 데이터 임시저장 구현

### DIFF
--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/dto/TaxInvoiceResponseDTO.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/dto/TaxInvoiceResponseDTO.java
@@ -1,6 +1,7 @@
 package Seoul_Milk.sm_server.domain.taxInvoice.dto;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.TaxInvoice;
+import Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -57,7 +58,7 @@ public class TaxInvoiceResponseDTO {
         @Schema(description = "공급받는자 성명") String suName,
         @Schema(description = "세금명세서 이미지 URL") String imageUrl,
         @Schema(description = "에러 상세 내역") List<String> errorDetails,
-        @Schema(description = "임시저장 여부") Boolean isTemporary,
+        @Schema(description = "임시저장 여부") TempStatus isTemporary,
         @Schema(description = "생성일자") LocalDateTime createdAt
     ) {
         public static GetOne from(TaxInvoice taxInvoice) {

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
@@ -115,7 +115,7 @@ public class TaxInvoice {
                 .suName(suName)
                 .member(member)
                 .errorDetails(errorDetails)
-                .isTemporary(true)
+                .isTemporary(INITIAL)
                 .build();
     }
 
@@ -140,7 +140,7 @@ public class TaxInvoice {
     }
 
     /** 임시 저장 여부 변경 **/
-    public void updateIsTemp(boolean isTemporary) {
+    public void updateIsTemp(TempStatus isTemporary) {
         this.isTemporary = isTemporary;
     }
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
@@ -1,6 +1,7 @@
 package Seoul_Milk.sm_server.domain.taxInvoice.entity;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus;
+import Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus;
 import Seoul_Milk.sm_server.domain.taxInvoiceFile.entity.TaxInvoiceFile;
 import Seoul_Milk.sm_server.login.entity.MemberEntity;
 import jakarta.persistence.*;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.*;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.INITIAL;
 
 @Entity
 @Getter
@@ -70,7 +72,7 @@ public class TaxInvoice {
 
     @Builder.Default
     @Column(name = "IS_TEMPORARY")
-    private Boolean isTemporary = true;
+    private TempStatus isTemporary = INITIAL;
 
     @CreatedDate
     @Column(name = "CREATED_AT", updatable = false)

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/entity/TaxInvoice.java
@@ -70,6 +70,7 @@ public class TaxInvoice {
     @BatchSize(size = 10)
     private List<String> errorDetails = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
     @Builder.Default
     @Column(name = "IS_TEMPORARY")
     private TempStatus isTemporary = INITIAL;

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/enums/TempStatus.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/enums/TempStatus.java
@@ -1,0 +1,5 @@
+package Seoul_Milk.sm_server.domain.taxInvoice.enums;
+
+public enum TempStatus {
+    INITIAL, UNTEMP, TEMP // initial : 처음 불러왔을 때, untemp : 임시저장x, temp : 임시저장된 상태
+}

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepository.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepository.java
@@ -31,5 +31,8 @@ public interface TaxInvoiceRepository {
 
     //임시저장 상태가 INITIAL인건 모두 Untemp로 바꾸기
     void updateInitialToUntemp(List<Long> taxInvoiceIds);
+
+    //임시저장 상태를 모두 TEMP로 바꾸기
+    void updateIsTemporaryToTemp(List<Long> taxInvoiceIds);
 }
 

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepository.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepository.java
@@ -28,5 +28,8 @@ public interface TaxInvoiceRepository {
     void deleteAll(List<TaxInvoice> taxInvoices);
     Page<TaxInvoice> searchConsumerOrProvider(String poc, String employeeId, ProcessStatus processStatus, MemberEntity member, Pageable pageable);
     long getProcessStatusCount(ProcessStatus processStatus, MemberEntity member);
+
+    //임시저장 상태가 INITIAL인건 모두 Untemp로 바꾸기
+    void updateInitialToUntemp(List<Long> taxInvoiceIds);
 }
 

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -3,10 +3,12 @@ package Seoul_Milk.sm_server.domain.taxInvoice.repository;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.APPROVED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.REJECTED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.UNAPPROVED;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.TEMP;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.QTaxInvoice;
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.TaxInvoice;
 import Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus;
+import Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus;
 import Seoul_Milk.sm_server.domain.taxInvoiceFile.entity.QTaxInvoiceFile;
 import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.TaxInvoiceSearchResult;
 import Seoul_Milk.sm_server.global.exception.CustomException;
@@ -122,7 +124,7 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
         return queryFactory.selectFrom(taxInvoice)
                 .where(
                         taxInvoice.member.eq(member),
-                        taxInvoice.isTemporary.isTrue()
+                        taxInvoice.isTemporary.eq(TEMP)
                 )
                 .fetch();
     }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -212,6 +212,9 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
             whereClause.and(taxInvoice.processStatus.eq(processStatus));
         }
 
+        //임시저장 여부 조건 추가
+        whereClause.and(taxInvoice.isTemporary.eq(UNTEMP).not());
+
         long total = Optional.ofNullable(
                 queryFactory
                         .select(Wildcard.count)

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -3,7 +3,9 @@ package Seoul_Milk.sm_server.domain.taxInvoice.repository;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.APPROVED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.REJECTED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.UNAPPROVED;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.INITIAL;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.TEMP;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.UNTEMP;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.QTaxInvoice;
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.TaxInvoice;
@@ -20,6 +22,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -167,6 +170,21 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
                         .fetchOne()
         ).orElse(0L);
         return count;
+    }
+
+    //임시저장 상태가 INITIAL인건 모두 Untemp로 바꾸기
+    @Override
+    @Transactional
+    public void updateInitialToUntemp(List<Long> taxInvoiceIds) {
+        QTaxInvoice taxInvoice = QTaxInvoice.taxInvoice;
+        queryFactory
+                .update(taxInvoice)
+                .set(taxInvoice.isTemporary, UNTEMP) // UNTEMP로 변경
+                .where(
+                        taxInvoice.taxInvoiceId.in(taxInvoiceIds)
+                                .and(taxInvoice.isTemporary.eq(INITIAL)) // INITIAL인 것만 변경
+                )
+                .execute();
     }
 
     @Override

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -188,6 +188,16 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
     }
 
     @Override
+    public void updateIsTemporaryToTemp(List<Long> taxInvoiceIds) {
+        QTaxInvoice taxInvoice = QTaxInvoice.taxInvoice;
+        queryFactory
+                .update(taxInvoice)
+                .set(taxInvoice.isTemporary, TEMP) // TEMP로 변경
+                .where(taxInvoice.taxInvoiceId.in(taxInvoiceIds)) // 특정 ID들만 업데이트
+                .execute();
+    }
+
+    @Override
     public Page<TaxInvoice> searchConsumerOrProvider(String poc, String employeeId, ProcessStatus processStatus, MemberEntity member, Pageable pageable) {
         QTaxInvoice taxInvoice = QTaxInvoice.taxInvoice;
         QMemberEntity memberEntity = QMemberEntity.memberEntity;

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -202,10 +202,6 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
                         .fetchOne()
         ).orElse(0L);
 
-        BooleanBuilder approvedWhereClause = new BooleanBuilder();
-        approvedWhereClause.and(whereClause).and(taxInvoice.processStatus.eq(APPROVED));
-
-
         List<TaxInvoice> results = queryFactory
                 .selectFrom(taxInvoice)
                 .leftJoin(taxInvoice.member, memberEntity).fetchJoin()

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/service/TmpTaxInvoiceServiceImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/service/TmpTaxInvoiceServiceImpl.java
@@ -1,7 +1,11 @@
 package Seoul_Milk.sm_server.domain.taxInvoice.service;
 
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.TEMP;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.UNTEMP;
+
 import Seoul_Milk.sm_server.domain.taxInvoice.dto.TaxInvoiceResponseDTO;
 import Seoul_Milk.sm_server.domain.taxInvoice.entity.TaxInvoice;
+import Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus;
 import Seoul_Milk.sm_server.domain.taxInvoice.repository.TaxInvoiceRepository;
 import Seoul_Milk.sm_server.global.exception.CustomException;
 import Seoul_Milk.sm_server.global.exception.ErrorCode;
@@ -49,7 +53,7 @@ public class TmpTaxInvoiceServiceImpl implements TmpTaxInvoiceService {
             throw new CustomException(ErrorCode.TAX_INVOICE_NOT_EXIST);
         }
 
-        taxInvoices.forEach(invoice -> invoice.updateIsTemp(true));
+        taxInvoices.forEach(invoice -> invoice.updateIsTemp(TEMP));
         taxInvoiceRepository.saveAll(taxInvoices);
     }
 
@@ -71,7 +75,7 @@ public class TmpTaxInvoiceServiceImpl implements TmpTaxInvoiceService {
             throw new CustomException(ErrorCode.TAX_INVOICE_NOT_EXIST);
         }
 
-        taxInvoices.forEach(invoice -> invoice.updateIsTemp(false));
+        taxInvoices.forEach(invoice -> invoice.updateIsTemp(UNTEMP));
         taxInvoiceRepository.saveAll(taxInvoices);
     }
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/controller/TaxInvoiceValidationHistoryController.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/controller/TaxInvoiceValidationHistoryController.java
@@ -2,7 +2,7 @@ package Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.controller;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus;
 import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.TaxInvoiceSearchResult;
-import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.request.DeleteTaxInvoiceRequest;
+import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.request.TaxInvoiceRequest;
 import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.service.TaxInvoiceValidationService;
 import Seoul_Milk.sm_server.global.annotation.CurrentMember;
 import Seoul_Milk.sm_server.global.dto.response.SuccessResponse;
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,9 +42,19 @@ public class TaxInvoiceValidationHistoryController {
     @DeleteMapping
     public SuccessResponse<Void> deleteValidationTaxInvoice(
             @CurrentMember MemberEntity memberEntity,
-            @RequestBody DeleteTaxInvoiceRequest deleteTaxInvoiceRequest
+            @RequestBody TaxInvoiceRequest taxInvoiceRequest
     ){
-        return SuccessResponse.ok(taxInvoiceValidationService.deleteValidationTaxInvoice(memberEntity, deleteTaxInvoiceRequest));
+        return SuccessResponse.ok(taxInvoiceValidationService.deleteValidationTaxInvoice(memberEntity,
+                taxInvoiceRequest));
+    }
+
+    @Operation(summary = "<RE_01> 임시 저장 api")
+    @PostMapping("/temp")
+    public SuccessResponse<Void> tempSave(
+            @CurrentMember MemberEntity memberEntity,
+            @RequestBody TaxInvoiceRequest taxInvoiceRequest
+    ){
+        return SuccessResponse.ok(taxInvoiceValidationService.tempSave(memberEntity, taxInvoiceRequest));
     }
 
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/dto/request/TaxInvoiceRequest.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/dto/request/TaxInvoiceRequest.java
@@ -5,7 +5,7 @@ import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class DeleteTaxInvoiceRequest {
+public class TaxInvoiceRequest {
     @Schema(description = "검증된 세금계산서 pk값 리스트")
     private List<Long> taxInvoiceIdList;
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/service/TaxInvoiceValidationService.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/service/TaxInvoiceValidationService.java
@@ -2,11 +2,13 @@ package Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.service;
 
 import Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus;
 import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.TaxInvoiceSearchResult;
-import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.request.DeleteTaxInvoiceRequest;
+import Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.dto.request.TaxInvoiceRequest;
 import Seoul_Milk.sm_server.login.entity.MemberEntity;
 
 public interface TaxInvoiceValidationService {
     TaxInvoiceSearchResult.GetData searchByProviderOrConsumer(MemberEntity memberEntity, ProcessStatus processStatus, String poc, int page, int size);
 
-    Void deleteValidationTaxInvoice(MemberEntity memberEntity, DeleteTaxInvoiceRequest deleteTaxInvoiceRequest);
+    Void deleteValidationTaxInvoice(MemberEntity memberEntity, TaxInvoiceRequest taxInvoiceRequest);
+
+    Void tempSave(MemberEntity memberEntity, TaxInvoiceRequest taxInvoiceRequest);
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/service/TaxInvoiceValidationServiceImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/service/TaxInvoiceValidationServiceImpl.java
@@ -3,6 +3,7 @@ package Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.service;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.APPROVED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.REJECTED;
 import static Seoul_Milk.sm_server.domain.taxInvoice.enums.ProcessStatus.UNAPPROVED;
+import static Seoul_Milk.sm_server.domain.taxInvoice.enums.TempStatus.INITIAL;
 import static Seoul_Milk.sm_server.global.exception.ErrorCode.DO_NOT_ACCESS_OTHER_TAX_INVOICE;
 import static Seoul_Milk.sm_server.global.exception.ErrorCode.TAX_INVOICE_NOT_EXIST;
 
@@ -37,6 +38,12 @@ public class TaxInvoiceValidationServiceImpl implements TaxInvoiceValidationServ
         Long approved = taxInvoiceRepository.getProcessStatusCount(APPROVED, memberEntity);
         Long rejected = taxInvoiceRepository.getProcessStatusCount(REJECTED, memberEntity);
         Long unapproved = taxInvoiceRepository.getProcessStatusCount(UNAPPROVED, memberEntity);
+
+        List<Long> taxInvoiceIds = taxInvoicePage.getContent().stream()
+                .map(TaxInvoice::getTaxInvoiceId)
+                .toList();
+        //임시저장 상태가 INITIAL인건 모두 Untemp로 바꾸기
+        taxInvoiceRepository.updateInitialToUntemp(taxInvoiceIds);
 
         List<GetHistoryData> historyDataList = taxInvoicePage.stream()
                 .map(taxInvoice -> TaxInvoiceValidationHistoryDTO.GetHistoryData.from(taxInvoice, taxInvoice.getFile()))

--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/validator/TaxInvoiceValidator.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoiceValidationHistory/validator/TaxInvoiceValidator.java
@@ -1,0 +1,43 @@
+package Seoul_Milk.sm_server.domain.taxInvoiceValidationHistory.validator;
+
+import static Seoul_Milk.sm_server.global.exception.ErrorCode.DO_NOT_ACCESS_OTHER_TAX_INVOICE;
+import static Seoul_Milk.sm_server.global.exception.ErrorCode.TAX_INVOICE_NOT_EXIST;
+
+import Seoul_Milk.sm_server.domain.taxInvoice.entity.TaxInvoice;
+import Seoul_Milk.sm_server.domain.taxInvoice.repository.TaxInvoiceRepository;
+import Seoul_Milk.sm_server.global.exception.CustomException;
+import Seoul_Milk.sm_server.login.entity.MemberEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * TaxInvoice 엔티티 검증클래스
+ * 유저가 테이블에(존재하지 않는 pk값) 없는 엔티티를 가져오려고 하거나
+ * 다른 유저의 TaxInvoice값을 가져오려고 할때 Exception발생
+ */
+@Component
+@RequiredArgsConstructor
+public class TaxInvoiceValidator {
+
+    /**
+     * 세금계산서 존재 여부 검증
+     */
+    public void validateExistence(List<TaxInvoice> taxInvoices, List<Long> requestedIds) {
+        if (taxInvoices.size() != requestedIds.size()) {
+            throw new CustomException(TAX_INVOICE_NOT_EXIST);
+        }
+    }
+
+    /**
+     * 사용자가 해당 세금계산서를 조작할 권한이 있는지 검증
+     */
+    public void validateOwnership(MemberEntity memberEntity, List<TaxInvoice> taxInvoices) {
+        boolean hasUnauthorizedAccess = taxInvoices.stream()
+                .anyMatch(invoice -> !invoice.getMember().getId().equals(memberEntity.getId()));
+
+        if (hasUnauthorizedAccess) {
+            throw new CustomException(DO_NOT_ACCESS_OTHER_TAX_INVOICE);
+        }
+    }
+}


### PR DESCRIPTION
### 📍 PR Type
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

### ✨ Related Issue
- #47 
---

### 📌 Task Details
- [x] TaxInvoice 테이블에 isTemporary필드 타입 Enum으로 변경(INITIAL, UNTEMP, TEMP)
- [x] TaxInvoice isTemporary필드 타입 수정됨에 따라 그와 연관된 메서드도 수정
- [x] 조회 시 isTemporary상태가 INITIAL일 경우 상태 UNTEMP로 변경하는 로직 추가
- [x] 조회 시 isTemporary상태가 UNTEMP일 경우 안가져오게끔 수정
- [x] 검증 내역 데이터 임시저장 api 구현
- [x] 삭제 api와 임시저장 api 구현에서 사용자 입력하는 검증하는 로직이 겹쳐서 이 부분을 따로 validator클래스로 분리
---
