### PR TITLE
fix: OCR 요청 Controller에 임시저장 이미지 ID 리스트 입력받도록 수정 #68

### DIFF
--- a/src/main/java/Seoul_Milk/sm_server/domain/image/service/ImageService.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/image/service/ImageService.java
@@ -12,5 +12,5 @@ public interface ImageService {
     Page<ImageResponseDTO.GetOne> getAll(MemberEntity member, int page, int size);
     void markAsTemporary(List<MultipartFile> images, MemberEntity member);
     void removeFromTemporary(MemberEntity member, List<Long> imageIds);
-    List<Image> getTempImagesForOcr(MemberEntity member);
+    List<Image> getTempImagesByIds(MemberEntity member, List<Long> imageIds);
 }

--- a/src/main/java/Seoul_Milk/sm_server/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/image/service/ImageServiceImpl.java
@@ -81,8 +81,12 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public List<Image> getTempImagesForOcr(MemberEntity member) {
-        List<Image> images = imageRepository.findTmpAllByMember(member);
+    public List<Image> getTempImagesByIds(MemberEntity member, List<Long> imageIds) {
+        if (imageIds == null || imageIds.isEmpty()) {
+            throw new CustomException(ErrorCode.TMP_IMAGE_NOT_EXIST);
+        }
+
+        List<Image> images = imageRepository.findByMemberAndIds(member, imageIds);
 
         if (images.isEmpty()) {
             throw new CustomException(ErrorCode.TMP_IMAGE_NOT_EXIST);


### PR DESCRIPTION
### 📍 PR Type
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

### ✨ Related Issue
- #68 
---

### 📌 Task Details
- [x] 기존 OCR 업로드 컨트롤러는 해당 사용자의 임시저장 이미지를 다 요청받았는데, 선택하여 입력하도록 수정
---
