### PR TITLE
🐛 RE_01 검색api에서 임시저장이 안된 계산서의 개수까지 카운트되는 현상 해결

### DIFF
--- a/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
+++ b/src/main/java/Seoul_Milk/sm_server/domain/taxInvoice/repository/TaxInvoiceRepositoryImpl.java
@@ -157,6 +157,7 @@ public class TaxInvoiceRepositoryImpl implements TaxInvoiceRepository {
         if(processStatus != null){
             whereClause.and(taxInvoice.processStatus.eq(processStatus));
         }
+        whereClause.and(taxInvoice.isTemporary.eq(UNTEMP).not());
         //최신 100개 데이터만 고려
         List<Long> latestIds = queryFactory
                 .select(taxInvoice.taxInvoiceId)


### PR DESCRIPTION
### 📍 PR Type
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

### ✨ Related Issue
- #94 
---

### 📌 Task Details
- [x] 검색api에서 임시저장이 안된 계산서의 개수까지 카운트되는 현상 해결
---
